### PR TITLE
add new, show notification of time that elapsed from last update date…

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -38,6 +38,9 @@
     "popup_hr": {
         "message": "Show horizontal rule with Backlog syntax(\"---\" or \"___\")"
     },
+    "popup_old_post": {
+        "message": "Show notification in old Wiki"
+    },
     "popup_general": {
         "message": "General"
     },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -3,7 +3,7 @@
         "message": "Backlog Power Ups - Backlogを便利に"
     },
     "app_description": {
-        "message": "Backlogの機能をパワーアップします。10個の機能追加があります。"
+        "message": "Backlogの機能をパワーアップします。11個の機能追加があります。"
     },
     "popup_apply_button": {
         "message": "適用"
@@ -37,6 +37,9 @@
     },
     "popup_hr": {
         "message": "Backlog記法で水平線を表示(\"---\" もしくは \"___\")"
+    },
+    "popup_old_post": {
+        "message": "最終更新日から1年以上経過した記事にお知らせを表示する"
     },
     "popup_general": {
         "message": "一般"

--- a/libs/power-ups.js
+++ b/libs/power-ups.js
@@ -14,7 +14,8 @@ const POWER_UP_PLUGINS = [
             "copy-wiki", 
             "child-page",
             "plantuml",
-            "hr"
+            "hr",
+            "old-post"
         ]
     },
     {
@@ -30,7 +31,8 @@ const DEFAULT_DISABLED_PLUGINS = [
     "extend-desc",
     "total-time",
     "plantuml",
-    "relative-date"
+    "relative-date",
+    "old-post"
 ];
 
 class PowerUps {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "permissions": [
     "tabs",
-    "storage"
+    "storage",
+    "webRequest"
   ],
   "icons": { 
    "128": "icon128.png" 
@@ -99,6 +100,15 @@
       ],
       "all_frames": true,
       "js": ["libs/jquery.js", "libs/power-ups.js", "plugins/hr/hr.js"]
+    },
+    {
+      "matches": [
+        "https://*.backlog.jp/wiki/*/*",
+        "https://*.backlogtool.com/wiki/*/*",
+        "https://*.backlog.com/wiki/*/*"
+      ],
+      "all_frames": true,
+      "js": ["libs/power-ups.js", "plugins/old-post/old-post.js"]
     },
     {
       "matches": [

--- a/plugins/old-post/old-post.js
+++ b/plugins/old-post/old-post.js
@@ -1,0 +1,68 @@
+(() => {
+  const showNotification = () => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", window.location.href, true);
+    xhr.send();
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === 4) {
+        // get now date from server
+        const serverDate = new Date(xhr.getResponseHeader("Date"));
+        const yyyy = serverDate.getFullYear();
+        const MM = ("0" + (serverDate.getMonth() + 1)).slice(-2);
+        const dd = ("0" + serverDate.getDate()).slice(-2);
+        const hh = ("0" + serverDate.getHours()).slice(-2);
+        const mm = ("0" + serverDate.getMinutes()).slice(-2);
+        const ss = ("0" + serverDate.getSeconds()).slice(-2);
+        const nowDate =
+          yyyy + "/" + MM + "/" + dd + " " + hh + ":" + mm + ":" + ss;
+
+        // from Backlog DOM
+        const userIconSet = document.querySelectorAll(
+          ".user-history > .user-icon-set"
+        );
+        const lastElText = userIconSet[userIconSet.length - 1].querySelector(
+          ".user-icon-set__text"
+        ).innerHTML;
+        const lastUpDate = lastElText.match(
+          /(\d{4})(\/)(\d{2})(\/)(\d{2})(\s)(\d{2})(\:)(\d{2})(\:)(\d{2})/
+        )[0];
+
+        // calc diff
+        const msDiff =
+          new Date(nowDate).getTime() - new Date(lastUpDate).getTime();
+        const daysDiff = Math.floor(msDiff / (1000 * 60 * 60 * 24));
+
+        // notification element
+        if (daysDiff > 364) {
+          const notification = document.createElement("p");
+          // !!! PLEASE CHANGE ACCORDING TO YOUR STYLE GUIDE !!!
+          Object.assign(notification.style, {
+            backgroundColor: "#ffe79a",
+            color: "#533f03",
+            padding: "16px"
+          });
+          const message =
+            PowerUps.getLang() == "ja"
+              ? "最終更新日から1年以上が経過しています。"
+              : "More than 1 year has passed since the last update date.";
+          notification.innerHTML = message;
+
+          // to Backlog UI
+          document
+            .getElementById("bodyLeft")
+            .insertBefore(
+              notification,
+              document.getElementById("mainTitle").nextSibling
+            );
+        }
+      }
+    };
+  };
+
+  PowerUps.isEnabled("old-post", enabled => {
+    if (enabled) {
+      if (window.location.href.endsWith("/edit")) return false;
+      showNotification();
+    }
+  });
+})();


### PR DESCRIPTION
… to wiki

![6c0d3b25de1d149bf5fb8ec104a663bb](https://user-images.githubusercontent.com/4241290/44770279-863d0e00-aba2-11e8-9cb1-f7c8a22fd150.png)

Hi, there :)
I implemented a function to notify the wiki that passed more than 1 year since the last update date.
Because I wanted it.
I think that it is better to tailor the styling of notification elements to your style guide, but I did not understand it.
In the meantime, it is resolved because `background.js` displays an error.

```
Uncaught TypeError: Cannot read property 'onHeadersReceived' of undefined
    at background.js:47
```

_manifest.json_
```sh
"permissions": [
  "tabs",
  "storage",
  "webRequest" // added
],
```

Also, it seems strange that the behavior of the pop-up checkboxes and buttons is strange, but it could not be solved :(
I am glad if you can check it.

最終更新日から1年以上経過した Wiki にその旨を通知するプラグインが欲しかったため、実装してみました。
通知要素のスタイルは Backlog のスタイルガイドに合わせた方がいいと思うのですが、よく分かりませんでした。。
ついでに、background.js でエラーが出ていたので解消しました（上記）。
それと、ポップアップのチェックボックスと適用ボタンの挙動が不思議な気がするのですが、解決できていません。
ご確認いただけたらうれしいです。