### PR TITLE
Added the function to enter an issue key from a shortcut and open to that issue

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -61,5 +61,8 @@
     },
     "popup_watch_list": {
         "message": "Show assignee and due date on watch list"
+    },
+    "popup_jump_issue": {
+        "message": "Press Ctrl(Cmd)+K to enter the issue key and open to it"
     }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -61,5 +61,8 @@
     },
     "popup_watch_list": {
         "message": "ウォッチリストに担当者と期限日を表示する"
+    },
+    "popup_jump_issue": {
+        "message": "Ctrl(Cmd)+Kで課題キーを入力して、その課題を開く"
     }
 }

--- a/libs/power-ups.js
+++ b/libs/power-ups.js
@@ -6,7 +6,8 @@ const POWER_UP_PLUGINS = [
             "auto-resolution",
             "extend-desc",
             "total-time",
-            "copy-issue-keys-and-subjects"
+            "copy-issue-keys-and-subjects",
+            "jump-issue"
         ]
     },
     {
@@ -41,7 +42,8 @@ const DEFAULT_DISABLED_PLUGINS = [
     "plantuml",
     "absolute-date",
     "old-post",
-    "watch-list"
+    "watch-list",
+    "jump-issue"
 ];
 
 class PowerUps {

--- a/manifest.json
+++ b/manifest.json
@@ -171,7 +171,7 @@
         "https://*.backlogtool.com/*",
         "https://*.backlog.com/*"
       ],
-      "js": ["libs/jquery.js", "libs/power-ups.js", "plugins/watch-list/watch-list.js"]
+      "js": ["libs/jquery.js", "libs/power-ups.js", "plugins/watch-list/watch-list.js", "plugins/jump-issue/jump-issue.js"]
     }
   ]
 }

--- a/plugins/jump-issue/jump-issue.js
+++ b/plugins/jump-issue/jump-issue.js
@@ -1,0 +1,68 @@
+(() => {
+  const lang = PowerUps.getLang();
+
+  const RES = lang == "ja" ? {
+    prompt: "移動先の課題キーまたは課題キーの番号を入力してください。",
+    alert: "課題キーのフォーマットが無効です。",
+    missing: "入力されたキーの課題が見つかりません。",
+  } : {
+    prompt: "Please enter the destination issue key or issue key number",
+    alert: "Issue key format is invalid",
+    missing: "Issue not found for the entered issue key",
+  };
+
+  function main(e) {
+    if (!window.Backlog || !window.Backlog.resource) {
+      return;
+    }
+
+    const projectKey = window.Backlog.resource["project.key"];
+
+    if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+      let issueNum;
+      while (true) {
+        issueNum = prompt(RES.prompt);
+        if (!issueNum) {
+          return;
+        }
+        issueNum = issueNum.replace(`${projectKey}-`, "");
+        if (!issueNum.match(/\d+/)) {
+          alert(RES.alert);
+          continue;
+        }
+        break;
+      }
+
+      const issueKey = `${projectKey}-${issueNum}`;
+      const issueUrl = `https://${location.hostname}/view/${issueKey}`;
+
+      fetch(issueUrl, {
+        method: "HEAD",
+        credentials: "include",
+      }).then(res => {
+        if (!res.ok) {
+          alert(RES.missing);
+          return;
+        }
+        location.href = issueUrl;
+      });
+    }
+  }
+
+  function addHook() {
+    window.addEventListener("keydown", async (e) => {
+      main(e);
+    });
+  }
+
+  PowerUps.isEnabled("jump-issue", (enabled) => {
+    if (enabled) {
+      PowerUps.injectScript(`
+        const RES = ${JSON.stringify(RES)};
+        ${main.toString()}
+        ${addHook.toString()}
+        addHook();
+      `);
+    }
+  });
+})();


### PR DESCRIPTION
よくZoomやMeetで「チケット◯◯が〜」という話をします。
対象の課題に直接飛べると便利だなと思い、機能追加の提案です。

![CleanShot_2024-06-05_19-00-08](https://github.com/nulab/backlog-power-ups/assets/5028163/15e586b5-d8ca-4d13-8004-8ad16c564064)

![CleanShot_2024-06-05_18-57-18](https://github.com/nulab/backlog-power-ups/assets/5028163/3b0cd2f9-9371-41cf-b8e0-49c0fa7013c3)
