### PR TITLE
chore(ci): add submit workflow

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -1,0 +1,96 @@
+name: Submit to Web Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        description: Environment to submit extension
+        default: dry-run
+        required: true
+      newversion:
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        description: New version
+        default: patch
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.bump_version.outputs.new_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: get the latest tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+
+      - name: bump version
+        id: bump_version
+        run: |
+          npm version ${{ steps.get_latest_tag.outputs.latest_tag }} --no-git-tag-version --allow-same-version
+          npm version ${{ github.event.inputs.newversion }}
+          
+          new_tag=$(git describe --tags --abbrev=0)
+          echo "Created new tag: ${new_tag}"
+          echo "new_tag=${new_tag}" >> $GITHUB_OUTPUT
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: zip extension
+        run: npx wxt zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: output
+          path: .output
+
+  submit:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: output
+          path: .output
+
+      - name: update version
+        run: npm version ${{ needs.build.outputs.new_tag }}
+
+      - name: submit to web store
+        run: npx wxt submit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.environment == 'dry-run' }}
+          CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_SKIP_SUBMIT_REVIEW: 'true'
+
+      - name: push the new tag
+        run: git push origin ${{ needs.build.outputs.new_tag }}

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -33,7 +33,7 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: configure Git
+      - name: configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -75,13 +75,13 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v5
         with:
           path: .output
 
-      - name: configure Git
+      - name: configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       new_tag: ${{ steps.bump_version.outputs.new_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -57,7 +57,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: output
           path: .output
 
   submit:
@@ -75,7 +74,6 @@ jobs:
 
       - uses: actions/download-artifact@v5
         with:
-          name: output
           path: .output
 
       - name: update version


### PR DESCRIPTION
## Overview

Added workflow for submitting extensions to the Chrome Web Store

## How to Use

Manually dispatch the workflow.

At this time, select the environment (Production or Dry Run) and the new version type (patch, minor, major).
If the workflow is successful, a tag will be created with the new version.

## Preparation

1. Add the `production` and `dry-run` environments.
1. Add the extension ID to Variables.
1. Add the credentials issued by `wxt init` to Secrets.

## Advanced Use

You can configure approvers for the `production` environment.
This allows maintainers to approve deployments before they are submitted.

https://docs.github.com/ja/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments